### PR TITLE
fix: opti when make bonus and remove -lcmocka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ override LIBFT := libft/libft.a
 
 override MLX := minilibx-linux/libmlx.a
 
-override LDFLAGS := -lmlx -lXext -lX11 -lft -lcmocka -lm
+override LDFLAGS := -lmlx -lXext -lX11 -lft -lm
 
 override LDLIBS := -L libft/ -L minilibx-linux/
 
@@ -120,7 +120,7 @@ all:
 
 .PHONY: bonus
 bonus:
-	@$(MAKE) MODE="bonus" TEST="$(TEST")" $(NAME) DEFINE="BONUS"
+	@$(MAKE) MODE="opti" TEST="$(TEST")" $(NAME) DEFINE="BONUS"
 
 #-j$(nproc) 
 .PHONY: debug


### PR DESCRIPTION
This pull request makes minor updates to the `Makefile`, primarily affecting build options and linked libraries. The most important changes are:

Build configuration updates:
* The `bonus` target now uses `MODE="opti"` instead of `MODE="bonus"`, which will change the build mode for bonus builds.

Linked libraries:
* Removed the `-lcmocka` flag from `LDFLAGS`, so the project will no longer link against the CMocka testing library by default.